### PR TITLE
[VIDEO-2227, VIDEO-2228] Add Tutorial, GCC support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(gdb) Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/tutorial/tests/tutorial-test",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${fileDirname}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set Disassembly Flavor to Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        },
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Aside from depending against this library, one must declare C++ structures accor
 > NOTE: `static` libraries can be used, however only one location throughout the entire codebase may register those types using `RTTR_REGISTER`.  The RTTR documentation makes a more vague statement about the use of these macros, however in testing, this previous statement is true.  If you want to register types from multiple locations, the libraries must all be dynamic and `RTTR_PLUGIN_REGISTRATION` used.
 
 This library includes a pair of headers at the top-level, `declaration.h` and `registration.h`, to help with organizing a codebase with the above concepts in mind.  In your header file where you are declaring structures, classes, use `declaration.h`.  When in an object file defining how RTTR should handle each object's members, the metadata, etc., use `registration.h`.  Each header has title comments pertaining to the typical usage of RTTR in each respect.
+
+## Tutorial
+
+This library includes a tutorial (see [Tutorial](tutorial/Tutorial.md)).  Configure the project for building the feature by setting the meson option: `-Dtutorial=enabled`.  Then, follow the linked tutorial.
+
+> NOTE: this requires `json-glib` to also be available in the environment as its library includes a readily-available _to string_ API for easier debugging.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Reflection Library
 
-This dynamic library is a collection of serialization tools written in C++ that utilize RTTR, the reflection library.  The goal is to make handling API structures a trivial matter.
+This dynamic library is a collection of serialization tools written in C++ that utilize [RTTR](https://www.rttr.org/), the runtime reflection library.  The goal is to make handling API structures a trivial matter.
 
 The library's only dependency is against RTTR itself, however its extensions for dealing with messages from other libraries like JsonGlib require the presence of those libraries.  If the library is not found in the environment, that feature is skipped.
+
+This library's [Tutorial](tutorial/Tutorial.md) covers several aspects of RTTR registration that are supported by the conversion logic in this library, however there are many other options and policies available.  Please see that project's [documentation](https://www.rttr.org/doc/master/classes.html) for more information.
 
 ## Building
 

--- a/meson.build
+++ b/meson.build
@@ -135,3 +135,10 @@ lldc_reflection_dep = declare_dependency(
 
 unset_variable('cdata')
 subdir('tests')
+
+if get_option('tutorial').enabled()
+  if not json_glib_dep.found()
+    error('jsonglib option must be enabled and found for the tutorial to work')
+  endif
+  subdir('tutorial')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
-option('socketio', type: 'boolean', value: 'false',
+option('socketio', type: 'boolean', value: false,
   description: 'If SocketIO-Client C++ is not found, build and use it')
-option('jsonglib', type: 'boolean', value: 'false',
+option('jsonglib', type: 'boolean', value: false,
   description: 'If JsonGLIB is not found, build and use it')
 option('tutorial', type: 'feature', value: 'disabled',
   description: 'Enable if working through the tutorial docs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,5 @@ option('socketio', type: 'boolean', value: 'false',
   description: 'If SocketIO-Client C++ is not found, build and use it')
 option('jsonglib', type: 'boolean', value: 'false',
   description: 'If JsonGLIB is not found, build and use it')
+option('tutorial', type: 'feature', value: 'disabled',
+  description: 'Enable if working through the tutorial docs')

--- a/src/converters/json-glib/from-json-glib.cpp
+++ b/src/converters/json-glib/from-json-glib.cpp
@@ -220,7 +220,7 @@ from_json_recursively (JsonObject *json_obj, ::rttr::instance obj2)
           auto view = var.create_associative_view();
           write_associative_view_recursively(json_array, view);
         }
-        else if (METADATA::is_blob(local_value_t)) {
+        else if (METADATA::is_blob(prop)) {
           auto json_str = json_to_string(member, TRUE);
           if (json_str) {
             var = std::string(json_str);
@@ -233,7 +233,7 @@ from_json_recursively (JsonObject *json_obj, ::rttr::instance obj2)
       }
       case JSON_NODE_OBJECT:
       {
-        if (METADATA::is_blob(value_t)) {
+        if (METADATA::is_blob(prop)) {
           auto json_str = json_to_string(member, TRUE);
           if (json_str) {
             var = std::string(json_str);
@@ -259,8 +259,8 @@ from_json_recursively (JsonObject *json_obj, ::rttr::instance obj2)
           }
 
           from_json_recursively(json_node_get_object(member), var);
-          prop.set_value(obj, var);
         }
+        prop.set_value(obj, var);
         break;
       }
       case JSON_NODE_NULL:

--- a/src/converters/json-glib/to-json-glib.cpp
+++ b/src/converters/json-glib/to-json-glib.cpp
@@ -282,14 +282,17 @@ to_json_recursive(const ::rttr::instance &obj2, JsonObject *json_object)
     bool optional = METADATA::is_optional(prop, prop_value, &matches_default);
 
     if (METADATA::is_no_serialize(prop)) {
+      did_write = true;
       continue; // skip it.
     }
 
     if (optional && matches_default) {
+      did_write = true;
       continue; // By implication, skip it.
     }
 
     if (optional && !prop_value) {
+      did_write = true;
       continue; // null-like and it's optional; skip it.
     }
 

--- a/src/converters/socket-io/from-socket-io.cpp
+++ b/src/converters/socket-io/from-socket-io.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <iostream>
-#include <format>
 
 #include <lldc-reflection/converters/socket-io.h>
 #include <lldc-reflection/metadata/metadata.h>

--- a/src/converters/socket-io/from-socket-io.cpp
+++ b/src/converters/socket-io/from-socket-io.cpp
@@ -223,7 +223,7 @@ from_socket_io_recursively (const sio_object &message, ::rttr::instance obj2)
           auto view = var.create_associative_view();
           write_associative_view_recursively(member->get_vector(), view);
         }
-        else if (METADATA::is_blob(local_value_t)) {
+        else if (METADATA::is_blob(prop)) {
           auto blob = member->get_binary();
           if (blob.get())
             var = std::string(blob.get()->c_str());
@@ -232,7 +232,7 @@ from_socket_io_recursively (const sio_object &message, ::rttr::instance obj2)
         break;
       }
       case ::sio::message::flag_object: {
-        if (METADATA::is_blob(value_t)) {
+        if (METADATA::is_blob(prop)) {
           auto blob = member->get_binary();
           if (blob.get())
             var = std::string(blob.get()->c_str());
@@ -256,8 +256,8 @@ from_socket_io_recursively (const sio_object &message, ::rttr::instance obj2)
           }
 
           from_socket_io_recursively(member->get_map(), var);
-          prop.set_value(obj, var);
         }
+        prop.set_value(obj, var);
         break;
       }
       case ::sio::message::flag_null: {

--- a/src/converters/socket-io/to-socket-io.cpp
+++ b/src/converters/socket-io/to-socket-io.cpp
@@ -258,14 +258,17 @@ to_socket_io_recursive(const ::rttr::instance &obj2, sio_object &object)
     bool optional = METADATA::is_optional(prop, prop_value, &matches_default);
 
     if (METADATA::is_no_serialize(prop)) {
+      did_write = true;
       continue; // skip it
     }
 
     if (optional && matches_default) {
+      did_write = true;
       continue; // By implication, skip it.
     }
 
     if (optional && !prop_value) {
+      did_write = true;
       continue; // null-like and it's optional; skip it.
     }
 

--- a/src/converters/socket-io/to-socket-io.cpp
+++ b/src/converters/socket-io/to-socket-io.cpp
@@ -296,7 +296,7 @@ to_socket_io (::rttr::instance object)
     }
   }
 
-  return std::move(out);
+  return out;
 }
 
 }; // lldc::reflection::converters

--- a/src/metadata/metadata.cpp
+++ b/src/metadata/metadata.cpp
@@ -80,12 +80,4 @@ is_no_serialize(const ::rttr::property &property) {
   return false;
 }
 
-template <typename T>
-bool is_blob(const T &rttr_t) {
-  auto md = rttr_t.get_metadata(metadata::BLOB);
-  if (md.is_valid())
-    return md.to_bool();
-  return false;
-}
-
 }; // lldc::reflection::metadata

--- a/src/metadata/metadata.cpp
+++ b/src/metadata/metadata.cpp
@@ -64,6 +64,7 @@ is_optional(const ::rttr::property& property, const ::rttr::variant& reference, 
   if (result && has_default) {
     auto md_optional_default = property.get_metadata(metadata::OPTIONAL_DEFAULT);
     temp_matches_reference = (md_optional_default == reference);
+    result = temp_matches_reference;
   }
 
   if (matched_reference)

--- a/src/private/metadata/metadata.h
+++ b/src/private/metadata/metadata.h
@@ -10,6 +10,10 @@
 #include <rttr/registration>
 
 namespace lldc::reflection::metadata {
+extern const char* const OPTIONAL;
+extern const char* const OPTIONAL_DEFAULT;
+extern const char* const NO_SERIALIZE;
+extern const char* const BLOB;
 
 bool is_optional(const ::rttr::property &property, bool *has_default);
 bool is_optional(const ::rttr::property& property, const ::rttr::variant& reference, bool *matched_reference);
@@ -17,7 +21,12 @@ bool is_optional(const ::rttr::property& property, const ::rttr::variant& refere
 bool is_no_serialize(const ::rttr::property &propety);
 
 template <typename T>
-bool is_blob(const T &t);
+bool is_blob(const T &t) {
+  auto md = t.get_metadata(metadata::BLOB);
+  if (md.is_valid())
+    return md.to_bool();
+  return false;
+}
 template bool is_blob(const ::rttr::property &property);
 template bool is_blob(const ::rttr::type &_type);
 

--- a/tests/common/common/example_messages.h
+++ b/tests/common/common/example_messages.h
@@ -300,4 +300,13 @@ struct COMMON_TEST_API
   RTTR_ENABLE();
 };
 
+struct COMMON_TEST_API
+  MaybeEmpty {
+    static const long DEFAULT_VALUE;
+
+    long value = DEFAULT_VALUE;
+
+    RTTR_ENABLE();
+  };
+
 }; // lldc::testing

--- a/tests/common/common/example_messages.h
+++ b/tests/common/common/example_messages.h
@@ -152,7 +152,7 @@ SecondMessage : public ApiMessage {
 struct COMMON_TEST_API
 OptionalMemberMessage : public ApiMessage
 {
-  static const uint64_t DEFAULT_U64_VALUE = 86;
+  static const uint64_t DEFAULT_U64_VALUE;
 
   OptionalMemberMessage() :
     ApiMessage(Subject::optional_member_message),

--- a/tests/common/common/example_messages.h
+++ b/tests/common/common/example_messages.h
@@ -181,6 +181,9 @@ OptionalMemberMessage : public ApiMessage
   }
 
   struct Payload {
+    Payload() {}
+    virtual ~Payload() {}
+
     int32_t value;
 
     friend bool operator==(const Payload& lhs, const Payload& rhs) {

--- a/tests/common/src/example_messages.cpp
+++ b/tests/common/src/example_messages.cpp
@@ -26,6 +26,8 @@ namespace lldc::testing {
       throw ::lldc::reflection::exceptions::ReferenceValueComparisonMismatch();
     _subject = subject;
   }
+
+  const uint64_t OptionalMemberMessage::DEFAULT_U64_VALUE = 86;
 };
 
 

--- a/tests/common/src/example_messages.cpp
+++ b/tests/common/src/example_messages.cpp
@@ -28,6 +28,8 @@ namespace lldc::testing {
   }
 
   const uint64_t OptionalMemberMessage::DEFAULT_U64_VALUE = 86;
+
+  const long MaybeEmpty::DEFAULT_VALUE = 32;
 };
 
 
@@ -169,5 +171,10 @@ RTTR_PLUGIN_REGISTRATION {
     .property("vv-int", &T::MessageWithVectors::vv_int)
     .property("v-sptr", &T::MessageWithVectors::v_sptr)
     .property("v-obj", &T::MessageWithVectors::v_obj)
+    ;
+
+  ::rttr::registration::class_<T::MaybeEmpty>("maybe-empty")
+    .property("value", &T::MaybeEmpty::value)
+      (::lldc::reflection::metadata::set_is_optional_with_default(T::MaybeEmpty::DEFAULT_VALUE))
     ;
 };

--- a/tests/test-template/test-template.cpp
+++ b/tests/test-template/test-template.cpp
@@ -406,6 +406,31 @@ TEST(Optionals, DefaultedValueType) {
   uut_unref(temp);
 }
 
+TEST(Optionals, EmptyBecauseOptional) {
+  /**
+   * This test verifies that the "to" conversion will succeed even if all of the
+   * object's properties are skipped for one reason or another (i.e., optional):
+   */
+  MaybeEmpty input;
+  uut_type temp = nullptr;
+
+  // Sanity check - non-default value was handled and a valid object was produced.
+  input.value = MaybeEmpty::DEFAULT_VALUE + 1;
+  EXPECT_NO_THROW(temp = to_conversion(input));
+  EXPECT_TRUE((temp));
+  EXPECT_TRUE(member_check_function(temp, "value"));
+  uut_unref(temp);
+
+  // When set to the default value, the object will effectively have no members
+  // to insert into the JSON (it will be '{}'), but that should still be permitted
+  // even though the result will be ambiguous on de-serialization.
+  input.value = MaybeEmpty::DEFAULT_VALUE;
+  EXPECT_NO_THROW(temp = to_conversion(input));
+  EXPECT_TRUE((temp));
+  EXPECT_FALSE(member_check_function(temp, "value"));
+  uut_unref(temp);
+}
+
 TEST(StdAny, MapWithAny) {
   /**
    * The object has a parameter, 'properties' which is a std::map<std::string, std::any>.

--- a/tests/test-template/test-template.cpp
+++ b/tests/test-template/test-template.cpp
@@ -86,7 +86,7 @@ TEST(Examples, SetOnceBehavior) {
 TEST(Examples, GuardIncorrectConversions) {
   FirstMessage uut_first;
   SecondMessage uut_second;
-  uut_type converted_first;
+  uut_type converted_first = nullptr;
 
   EXPECT_NE(uut_first.GetSubject(), uut_second.GetSubject());
   EXPECT_NO_THROW(converted_first = to_conversion(uut_first));
@@ -105,7 +105,7 @@ TEST(Examples, InspectableProperty) {
   FirstMessage first;
   SecondMessage second;
   SecondMessage input;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   EXPECT_NO_THROW(temp = to_conversion(input));
   EXPECT_TRUE(from_conversion(temp, tester));
@@ -125,7 +125,7 @@ TEST(Examples, ApiMessage) {
    */
   ApiMessage uut (Subject::first_message);
   ApiMessage out;
-  uut_type converted_uut;
+  uut_type converted_uut = nullptr;
 
   EXPECT_NO_THROW(converted_uut = to_conversion(uut));
   EXPECT_TRUE(from_conversion(converted_uut, out));
@@ -136,7 +136,7 @@ TEST(Examples, ApiMessage) {
 
 TEST(Examples, FirstMessage) {
   FirstMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.body.data["some_key"] = "some_value";
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -148,7 +148,7 @@ TEST(Examples, FirstMessage) {
 
 TEST(Examples, SecondMessage) {
   SecondMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   // Run some values through every member to validate
   // the behavior and integrity of the conversion.
@@ -185,7 +185,7 @@ TEST(Examples, SecondMessage) {
   */
 TEST(Examples, PropertyRegistrationBehavior) {
   SimpleMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.name = "clever name";
   input.payload.member = "something testy";
@@ -228,7 +228,7 @@ TEST(Optionals, ToSkippedOnEmptyOrDefaulted) {
    * NOTE: There are other optional members which will not be skipped
    */
   OptionalMemberMessage input;
-  uut_type temp;
+  uut_type temp = nullptr;
   std::vector<std::string> optional_names = {
     "optional_string",
     "optional_vector",
@@ -279,7 +279,7 @@ TEST(Optionals, MissingRequiredWillFail) {
    * when restored from an empty object.
    */
   OptionalMemberMessage output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   // Verify that from fails if a required container member
   // is not given in the intermediate class.
@@ -294,7 +294,7 @@ TEST(Optionals, MissingRequiredWillFail) {
 
 TEST(Optionals, String) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_string = "is now set";
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -306,7 +306,7 @@ TEST(Optionals, String) {
 
 TEST(Optionals, Vector) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_vector.push_back(5);
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -318,7 +318,7 @@ TEST(Optionals, Vector) {
 
 TEST(Optionals, Map) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_map["test_value"] = 42;
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -330,7 +330,7 @@ TEST(Optionals, Map) {
 
 TEST(Optionals, SharedPointer) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_sptr = std::make_shared<OptionalMemberMessage::Payload>();
   input.optional_sptr->value = 53;
@@ -343,7 +343,7 @@ TEST(Optionals, SharedPointer) {
 
 TEST(Optionals, RawPointer) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_rawptr = new OptionalMemberMessage::Payload();
   input.optional_rawptr->value = 87;
@@ -356,7 +356,7 @@ TEST(Optionals, RawPointer) {
 
 TEST(Optionals, ObjectByValue) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_obj.value = 32;
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -368,7 +368,7 @@ TEST(Optionals, ObjectByValue) {
 
 TEST(Optionals, ValueType) {
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.optional_uint64 = 58;
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -387,7 +387,7 @@ TEST(Optionals, DefaultedValueType) {
    * existed in the intermediate stage and the output as the new value.
    */
   OptionalMemberMessage input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   EXPECT_EQ(input.optional_defaulted_uint64, OptionalMemberMessage::DEFAULT_U64_VALUE);
   EXPECT_NO_THROW(temp = to_conversion(input));
@@ -412,7 +412,7 @@ TEST(StdAny, MapWithAny) {
    * This test validates that the library handle inferring what to insert for "any".
    */
   MessageWithAnys input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.properties["int-valued"] = (int) 1234;
   input.properties["string-valued"] = std::string("something");
@@ -440,7 +440,7 @@ TEST(StdAny, MapWithAny) {
 
 TEST(Pointers, DestinationIsStdShared) {
   std::shared_ptr<SecondMessage> input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input = std::make_shared<SecondMessage>();
   input->some_bool = true;
@@ -460,7 +460,7 @@ TEST(Pointers, DestinationIsStdShared) {
 
 TEST(Pointers, DestinationIsRawPtr) {
   SecondMessage* input, * output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input = new SecondMessage();
   input->some_float = 86.0f;
@@ -484,7 +484,7 @@ TEST(Pointers, DestinationIsRawPtr) {
 
 TEST(Vectors, VectorOfValues) {
   MessageWithVectors input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.v_int = { 1, 2, 3 };
 
@@ -498,7 +498,7 @@ TEST(Vectors, VectorOfValues) {
 
 TEST(Vectors, VectorOfVectorOfValues) {
   MessageWithVectors input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.vv_int.push_back({ 1, 2, 3 });
 
@@ -512,7 +512,7 @@ TEST(Vectors, VectorOfVectorOfValues) {
 
 TEST(Vectors, VectorOfSharedPointers) {
   MessageWithVectors input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.v_sptr.push_back(std::make_shared<SimpleMessage>());
   input.v_sptr[0]->name = "Some Name";
@@ -528,7 +528,7 @@ TEST(Vectors, VectorOfSharedPointers) {
 
 TEST(Vectors, VectorOfValueObjects) {
   MessageWithVectors input, output;
-  uut_type temp;
+  uut_type temp = nullptr;
 
   input.v_obj.resize(1);
   input.v_obj[0].name = "Some Other Name";

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -37,6 +37,6 @@ The layout of this directory includes:
 
 ## Tutorial
 
-1. [A Basic Structure (steps 1-3 above)](tutorial/doc/01-a-basic-structure.md)
-2. [Getters, Setters, and Friends (4 above)](tutorial/doc/02-getters-setters-and-friends.md)
-3. [Handling Objects (5, 6, 7)](tutorial/doc/03-handling-objects.md)
+1. [A Basic Structure (steps 1-3 above)](doc/01-a-basic-structure.md)
+2. [Getters, Setters, and Friends (4 above)](doc/02-getters-setters-and-friends.md)
+3. [Handling Objects (5, 6, 7)](doc/03-handling-objects.md)

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -37,6 +37,6 @@ The layout of this directory includes:
 
 ## Tutorial
 
-[A Basic Structure (steps 1-3 above)](tutorial/doc/01-a-basic-structure.md)
-[Getters, Setters, and Friends (4 above)](tutorial/doc/02-getters-setters-and-friends.md)
-[Handling Objects (5, 6, 7)](tutorial/doc/03-handling-objects.md)
+1. [A Basic Structure (steps 1-3 above)](tutorial/doc/01-a-basic-structure.md)
+2. [Getters, Setters, and Friends (4 above)](tutorial/doc/02-getters-setters-and-friends.md)
+3. [Handling Objects (5, 6, 7)](tutorial/doc/03-handling-objects.md)

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -13,6 +13,7 @@ This tutorial provides the framework to compile a library and GTest -based appli
 9. Leveraging enumerations to strings, values, etc.
 10. Metadata: what does `optional` mean?
 11. Metadata: what about optionally serializing a member if the value matches a reference?
+12. Metadata: what does it mean to leave it as a `blob`?  What is a use case?
 
 ## Getting Started
 

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -45,3 +45,5 @@ The layout of this directory includes:
 2. [Getters, Setters, and Friends (4 above)](doc/02-getters-setters-and-friends.md)
 3. [Handling Objects (5, 6, 7)](doc/03-handling-objects.md)
 4. [Having Some (Sub)Class (8, 9)](doc/04-having-some-subclass.md)
+5. [Optional Data Members  (10, 11)](doc/05-optional-data-members.md)
+6. [How to use Blob (12)](doc/06-how-to-use-blob.md)

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -10,6 +10,7 @@ This tutorial provides the framework to compile a library and GTest -based appli
 6. Change the storage of the object member to a raw pointer.
 7. Change the storage of the object member to a shared pointer.
 8. Subclass a base message structure and register that subclass.
+9. Leveraging enumerations to strings, values, etc.
 
 ## Getting Started
 
@@ -40,3 +41,4 @@ The layout of this directory includes:
 1. [A Basic Structure (steps 1-3 above)](doc/01-a-basic-structure.md)
 2. [Getters, Setters, and Friends (4 above)](doc/02-getters-setters-and-friends.md)
 3. [Handling Objects (5, 6, 7)](doc/03-handling-objects.md)
+4. [Having Some (Sub)Class (8, 9)](doc/04-having-some-subclass.md)

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -1,0 +1,40 @@
+# LLDC Reflection (RTTR) Tutorial
+
+This tutorial provides the framework to compile a library and GTest -based application showing the steps necessary for using the lldc-reflection (and RTTR) libraries.  The goals of this document are to inform how to:
+
+1. Define a structure with value types that can be handled by the reflection library.
+2. Register your base structure with RTTR.
+3. Define a GTest that can serialize and deserialize the structure (verify success).
+4. Extend the design to include setters and getters for properties.
+5. Extend the design further with an object member (by value).
+6. Change the storage of the object member to a raw pointer.
+7. Change the storage of the object member to a shared pointer.
+8. Subclass a base message structure and register that subclass.
+
+## Getting Started
+
+For the sake of simplifying debugging, this design will serialize to/from JsonGlib for now, as it has a _to string_ API for easier printing of the intermediate object as well as testing _from string_ direct serialization in a human-readable way.  Therefore enable both the example and use of JsonGlib by at the root directory of this library:
+
+```
+rm -rf builddir
+meson setup -Djsonglib=true -Dtutorial=enabled builddir
+```
+
+Later compilation and tests are the usual:
+
+```
+meson compile -C builddir
+meson test -C builddir
+# etc.
+```
+
+The layout of this directory includes:
+
+| Path | Description |
+| ------ | --------- |
+| `lib` | The library where you will be adding your structures and handling the RTTR Registration definitions. |
+| `tests` | The GTest `main()` and related test cases. |
+
+## Tutorial
+
+[A Basic Structure (steps 1-3 above)](tutorial/doc/01-a-basic-structure.md)

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -11,6 +11,8 @@ This tutorial provides the framework to compile a library and GTest -based appli
 7. Change the storage of the object member to a shared pointer.
 8. Subclass a base message structure and register that subclass.
 9. Leveraging enumerations to strings, values, etc.
+10. Metadata: what does `optional` mean?
+11. Metadata: what about optionally serializing a member if the value matches a reference?
 
 ## Getting Started
 

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -38,3 +38,4 @@ The layout of this directory includes:
 ## Tutorial
 
 [A Basic Structure (steps 1-3 above)](tutorial/doc/01-a-basic-structure.md)
+[Getters, Setters, and Friends (4 above)](tutorial/doc/02-getters-setters-and-friends.md)

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -39,3 +39,4 @@ The layout of this directory includes:
 
 [A Basic Structure (steps 1-3 above)](tutorial/doc/01-a-basic-structure.md)
 [Getters, Setters, and Friends (4 above)](tutorial/doc/02-getters-setters-and-friends.md)
+[Handling Objects (5, 6, 7)](tutorial/doc/03-handling-objects.md)

--- a/tutorial/doc/01-a-basic-structure.md
+++ b/tutorial/doc/01-a-basic-structure.md
@@ -1,0 +1,127 @@
+# Adding a Basic Structure
+
+Anytime you add or modify a structure and want to also expose that property (or function) to RTTR, you need to perform at least two steps:
+
+1. Update the structure declaration (and definition, depending on what you are doing).
+2. Update the related RTTR registration for the change(s).
+
+The files you will be editing are:
+
+| Referred to as | Location |
+| -------------- | -------- |
+| _tutorial header_ | `lib/include/tutorial.hpp` |
+| _tutorial source_ | `lib/src/tutorial.cpp` |
+| _tutorial test_ | `tests/src/tutorial-test.cpp` |
+
+> **IMPORTANT:** Before we begin, please read the `main` in the tutorial test.  There is an important comment about our use of dynamic libraries here vs. potentially having to have RTTR load that library into memory for the test application.  If you find that the converter functions are doing nothing in the application you develop: this very well could be why!
+
+## Creating the First Structure
+
+Open the tutorial header file and find the marked area within the `tutorial` namespace where you should add your structure.  We will start with something very simple:
+
+```cpp
+// tutorial.hpp within the 'tutorial' namespace
+struct First {
+  std::string s_value;
+  uint64_t ui64_value;
+
+  friend bool operator==(const First &lhs, const First &rhs) {
+    return (lhs.s_value == rhs.s_value) && (lhs.ui64_value == rhs.ui64_value);
+  }
+
+  RTTR_ENABLE();
+};
+```
+
+The `RTTR_ENABLE(subclass or empty)` macro adds some private members to the class to facilitate RTTR's inspection of the type.  The `operator==` we'll use for now to help make tests easier to read.
+
+## Registering the First Structure
+
+Open the tutorial source and find the `RTTR_PLUGIN_REGISTRATION` body.
+
+> **IMPORTANT:** The tutorial library is being compiled as a shared library, which implies one could have multiple libraries defined with structures/classes utilizing RTTR, also linked dynamically, and serialization will work* (see introduction note).  On the other hand if you link to RTTR statically, you will need to build `lldc-reflection` statically as well as your library _and_ use `RTTR_REGISTRATION` (vs. `_PLUGIN_`) in a single object file where _ALL_ of your RTTR-enabled structures will be registered.
+
+Declare that this class (struct) exists, giving it a unique name.
+
+```cpp
+::rttr::registration::class_<First>("first");
+```
+
+If left completely empty like this, any valid object instance could be serialized to it as there are no property names to check or reject.  Prove that to yourself by updating `tutorial/tests/src/tutorial-test.cpp` with the following test:
+
+```cpp
+TEST(First, CanSerialize) {
+  auto raw_input = R"({ 'anything': 42 })";
+  auto input = json_from_string(raw_input, NULL);
+
+  ::tutorial::First output;
+  EXPECT_TRUE(lldc::reflection::converters::from_json_glib(input, output));
+  EXPECT_TRUE(output.s_value.empty());
+}
+```
+
+Recompile and run the test:
+
+```
+meson test -C builddir tutorial-test
+```
+
+It should succeed.
+
+> _TAKEAWAY:_ If you do not register properties, there is no way for anything to happen. Likewise if you want it ignored, just do not mention it, however the library does provide metadata for declaring to the reader that something is being treated as optional.  It is covered in a later tutorial.
+
+## Registering Properties
+
+Let's map the string property by updating the tutorial source file:
+
+```cpp
+::rttr::registration::class_<First>("first")
+  .property("something", &First::s_value)
+  .property("anything", &First::ui64_value)
+  ;
+```
+
+This is telling RTTR to marshal to/from the `s_value` member under the name `something` and `ui64_value` as `anything`.  Moreover by registering the properties, they are implicitly required the conversion routines.  Change the test to verify this new behavior:
+
+```cpp
+TEST(First, CanSerialize) {
+  auto input_json = json_from_string(R"({ 'anything': 42 })", NULL);
+  ::tutorial::First output;
+
+  // This should fail since 'something' is now registered, but is not
+  // in the input_json message.
+  EXPECT_FALSE(converters::from_json_glib(input_json, output));
+  json_node_unref(input_json);
+
+  // Change the input_json to also include 'something'.  Now that required property
+  // can be found in the source object so conversion will succeed.
+  input_json = json_from_string(R"({'anything': 42, 'something': 'everything'})", NULL);
+  output = ::tutorial::First();
+  EXPECT_TRUE(converters::from_json_glib(input_json, output));
+  EXPECT_FALSE(output.s_value.empty());
+  EXPECT_EQ(output.s_value, "everything");
+  EXPECT_EQ(output.ui64_value, 42);
+  json_node_unref(input_json);
+
+  // Likewise this should work.
+  ::tutorial::First input;
+  input.s_value    = "whatever";
+  input.ui64_value = 86;
+  EXPECT_TRUE((input_json = converters::to_json_glib(input)));
+  EXPECT_TRUE(converters::from_json_glib(input_json, output));
+  EXPECT_TRUE(input == output);
+  json_node_unref(input_json);
+}
+```
+
+Re-run the test (`meson test -C builddir tutorial-test`; if it does not automatically recompile, do that).  It should succed.
+
+First, the test attempts to convert what is an incomplete representation of the `First` object to verify that it will fail to perform that conversion to an instance of that class.
+
+Second, the test successfully converts a complete representation of the `First` object and verifies the output object has the expected values.
+
+Third, the test proves the other half of the conversion works too -- it converts from an instance of `First` to the intermediate `JsonNode*` instance and then back to another instance of `First`, which it confirms is equal to the input value.
+
+## Conclusion
+
+In this tutorial, it was shown how to declare a C++ structure for handling via RTTR.  Also shown are the nuances of library loading and the default behavior of property registration, making the property _required to be present_ to successfully deserialize it from the intermediate type.

--- a/tutorial/doc/02-getters-setters-and-friends.md
+++ b/tutorial/doc/02-getters-setters-and-friends.md
@@ -1,0 +1,102 @@
+# Getters, Setters, and Friends
+
+This tutorial builds off the introduction, which showed how to register a structure, its properties, and perform conversions in the test environment, by showing how to have RTTR identify getters and setters (public methods) and leverage being a `friend`.
+
+The files you will be editing are:
+
+| Referred to as | Location |
+| -------------- | -------- |
+| _tutorial header_ | `lib/include/tutorial.hpp` |
+| _tutorial source_ | `lib/src/tutorial.cpp` |
+| _tutorial test_ | `tests/src/tutorial-test.cpp` |
+
+## Creating "Second"
+
+To the tutorial header, add this structure, `Second`, which has a single private member, a `long`, called `__member` and public getter/setter methods for that member.
+
+```cpp
+struct Second {
+  auto GetMember() { return __member; }
+  void SetMember(long m) { __member = m; }
+
+  private:
+  long __member;
+
+  RTTR_ENABLE();
+};
+```
+
+In the tutorial source, register the property with the getter/setter:
+
+```cpp
+::rttr::registration::class_<Second>("second")
+  .property("member", &Second::GetMember, &Second::SetMember)
+  ;
+```
+
+And in the tutorial test, add something simple like this:
+
+```cpp
+TEST(Second, GetterSetter) {
+  ::tutorial::Second input, output;
+  JsonNode* temp = nullptr;
+
+  input.SetMember(50);
+  EXPECT_TRUE((temp = converters::to_json_glib(input)));
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(input.GetMember(), output.GetMember());
+  json_node_unref(temp);
+}
+```
+
+Compile and run the test.  It should succeed.
+
+As seen in the first tutorial, this test serializes and deserializes an object, then verifies the resulting objects are equal.  Since the property getter/setter were used in the registration, this all succeeds fine.
+
+> NOTE: RTTR also supports read-only registration, a topic not covered in this stack of tutorials but [it exists](https://www.rttr.org/doc/master/classrttr_1_1registration.html).
+
+## Being Friends
+
+What if that object's member should not be accessible?  For that, one can register the object with RTTR as a friend.  Modify the tutorial header definition to include:
+
+```cpp
+struct FriendSecond {
+  auto GetMember() { return __member; }
+
+  private:
+  long __member;
+
+  RTTR_REGISTRATION_FRIEND;
+};
+```
+
+> NOTE: In the above structure, the _getter_ is being included as a means to verify the serialization in the test.
+
+Next, register the structure as you normally would in the tutorial source file:
+
+```cpp
+::rttr::registration::class_<FriendSecond>("friend-second")
+  .property("member", &FriendSecond::__member)
+  ;
+```
+
+Then add a simple test to verify RTTR can set `__member` for us via that registered `member` property:
+
+```cpp
+TEST(FriendSecond, Friendly) {
+  auto input = json_from_string(R"({'member': 58})", NULL);
+  ::tutorial::FriendSecond output;
+
+  EXPECT_TRUE(converters::from_json_glib(input, output));
+  EXPECT_EQ(output.GetMember(), 58);
+  json_node_unref(input);
+}
+```
+
+Compile and run the test.
+
+The test deserializes an object that would match `FriendSecond`'s registered structure, a single property named `member`, and verifies that the stored value matches what is expected by using a public interface (purely there for conciseness of the tutorial).
+
+## Conclusion
+
+Covered in this tutorial were alternative methods for handling internal properties.  One can either register property getter/setter methods, mark the class as a `friend` of RTTR, or (not shown) register the property as read-only.

--- a/tutorial/doc/02-getters-setters-and-friends.md
+++ b/tutorial/doc/02-getters-setters-and-friends.md
@@ -66,7 +66,8 @@ struct FriendSecond {
   private:
   long __member;
 
-  RTTR_REGISTRATION_FRIEND;
+  RTTR_ENABLE();
+  RTTR_REGISTRATION_FRIEND; // <_<
 };
 ```
 

--- a/tutorial/doc/03-handling-objects.md
+++ b/tutorial/doc/03-handling-objects.md
@@ -1,0 +1,203 @@
+# Handling Objects
+
+Building off the first tutorial, this tutorial will show how to have an object with an object member (by value).  The design will then be extended to use a raw pointer member and finally a shared pointer member.
+
+The files you will be editing are:
+
+| Referred to as | Location |
+| -------------- | -------- |
+| _tutorial header_ | `lib/include/tutorial.hpp` |
+| _tutorial source_ | `lib/src/tutorial.cpp` |
+| _tutorial test_ | `tests/src/tutorial-test.cpp` |
+
+## Making Third, Payload
+
+Starting off, the `Third` structure will have a simple `Payload` member with a single `long` `value` member registered.  Edit the tutorial header to include them:
+
+```cpp
+struct Third {
+  struct Payload {
+    long value;
+
+    RTTR_ENABLE();
+  };
+
+  Payload payload;
+
+  RTTR_ENABLE();
+};
+```
+
+If you have been through the other tutorials, the above is self explanatory, so let's move on to the registration in the tutorial source:
+
+```cpp
+::rttr::registration::class_<Third>("third")
+  .property("payload", &Third::payload)
+  ;
+
+::rttr::registration::class_<Third::Payload>("third::payload")
+  .property("value", &Third::Payload::value)
+  ;
+```
+
+Again, you're 2 tutorials in and a pro at this (_right?_), so you wrote the above and went on to the test in the tutorial test:
+
+```cpp
+TEST(Third, ObjectMembers) {
+  auto temp = json_from_string(R"({'payload': { 'value': 12 } })", NULL);
+  ::tutorial::Third output;
+
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(output.payload.value, 12);
+  json_node_unref(temp);
+
+  ::tutorial::Third input;
+  input.payload.value = 83;
+
+  EXPECT_TRUE((temp = converters::to_json_glib(input)));
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(input.payload.value, output.payload.value);
+  json_node_unref(temp);
+}
+```
+
+Like the other tests, we verify that serialization from what we expect to be our raw source material, a JSON string object representation, works as expected.  And for good measure, the test verifies the to-from transition also works fine.
+
+You compile and run the test; it works.  Good job.
+
+## Raw Pointers
+
+Let us say you have a structure with a member that you want to exist as a pointer.  Feeling confident, you go modify the tutorial header to initialize it as a `nullptr` and delete it if necessary in the destructor:
+
+```cpp
+  struct Third {
+    struct Payload {
+      Payload() {}
+      virtual ~Payload() {}
+
+      long value;
+
+      RTTR_ENABLE();
+    };
+
+    Payload* payload; // <<<<< raw pointer
+
+    Third() : payload(nullptr) { }
+
+    ~Third() {
+      if (payload)
+        delete payload;
+    }
+
+    RTTR_ENABLE();
+  };
+```
+
+Over in the tutorial source, you look at the registration.  The member name didn't change, so the registration is the same.  Let's keep going.
+
+You continue to the test to change all your `.` to `->` and make sure you create a `Third::Payload` for that second half of the test:
+
+```cpp
+TEST(Third, ObjectMembers) {
+  auto temp = json_from_string(R"({'payload': { 'value': 12 } })", NULL);
+  ::tutorial::Third output;
+
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(output.payload->value, 12);
+  json_node_unref(temp);
+
+  ::tutorial::Third input;
+  input.payload = new ::tutorial::Third::Payload();
+  input.payload->value = 83;
+
+  EXPECT_TRUE((temp = converters::to_json_glib(input)));
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(input.payload->value, output.payload->value);
+  json_node_unref(temp);
+}
+```
+
+You're a pro.  You got this.  You compile and run the test.  It segfaults.  What is missing?
+
+In the debugger it occurs to you that the first `EXPECT_EQ` just hit an null pointer despite the conversion apparently succeeding.  RTTR needs to know how to make a `Third::Payload`.
+
+Back at the tutorial source, decorate the `Third::Payload` registration:
+
+```cpp
+  ::rttr::registration::class_<Third::Payload>("third::payload")
+    .constructor<>()(::rttr::policy::ctor::as_raw_ptr) // <_<
+    .property("value", &Third::Payload::value)
+    ;
+```
+
+You recompile and run the test again, it succeeds.
+
+> NOTE: currently, the conversion routines in this library do not treat a missing / unknown constructor for a given type as an error worthy of aborting the deserialization from the intermediate type.
+
+## Shared Pointers
+
+Fresh off that previous experience and knowing you would rather use a smart pointer, you change the tutorial header:
+
+```cpp
+struct Third {
+  struct Payload {
+    Payload() {}
+    virtual ~Payload() {}
+
+    long value;
+
+    RTTR_ENABLE();
+  };
+
+  std::shared_ptr<Payload> payload;
+
+  Third() : payload(nullptr) { }
+
+  ~Third() { }
+
+  RTTR_ENABLE();
+};
+```
+
+And then update the registration information for `Third::Payload` because you just learned that matters:
+
+```cpp
+::rttr::registration::class_<Third::Payload>("third::payload")
+  .constructor<>()(::rttr::policy::ctor::as_std_shared_ptr)
+  .property("value", &Third::Payload::value)
+  ;
+```
+
+Next you update the tutorial test to reset the smart pointer with our instance where that mattered:
+
+```cpp
+TEST(Third, ObjectMembers) {
+  auto temp = json_from_string(R"({'payload': { 'value': 12 } })", NULL);
+  ::tutorial::Third output;
+
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(output.payload->value, 12);
+  json_node_unref(temp);
+
+  ::tutorial::Third input;
+  input.payload.reset(new ::tutorial::Third::Payload()); // <-- shared pointer
+  input.payload->value = 83;
+
+  EXPECT_TRUE((temp = converters::to_json_glib(input)));
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_EQ(input.payload->value, output.payload->value);
+  json_node_unref(temp);
+}
+```
+
+You compile and run the test; it passes.  Good job.
+
+## More Information
+
+The `.constructor` registration has another policy for `as_object` for situations where that is necessary (MSVC is one instance where our first test would likely have failed).  Simply add it to your object registration and that constructor will now be known.
+
+The registration also takes arguments, like `.constructor<types...>(args...)(policy)`.  Constructors of this type are not currently supported in the conversion routines since there would be no clear way to indicate from what those `args...` should be sourced.
+
+## Conclusions
+
+In this tutorial you learned how to deal with object members stored by value, raw pointer, and shared pointer.  We walked confidently straight into a segfault and then fixed it.  And you're ready for more.

--- a/tutorial/doc/04-having-some-subclass.md
+++ b/tutorial/doc/04-having-some-subclass.md
@@ -1,0 +1,289 @@
+# Having Some (Sub)Class
+
+This tutorial covers how to decorate your structures in such a way that RTTR understands the class hierarchy when serializing objects.  It will also leverage what we have learned about property registration (or the lack thereof) to show a potential way to deal with martialling APIs that have a consistent field for a message _subject_ or _topic_.  We will accomplish that by registering an enumeration.
+
+The files you will be editing are:
+
+| Referred to as | Location |
+| -------------- | -------- |
+| _tutorial header_ | `lib/include/tutorial.hpp` |
+| _tutorial source_ | `lib/src/tutorial.cpp` |
+| _tutorial test_ | `tests/src/tutorial-test.cpp` |
+
+## Getting Started
+
+Some JSON-based APIs have a member for _subject_ or _topic_ which is typically an enumeration based off a string value.  If your application were trying to route these messages (assuming they're unsolicited), the flow of your application is usually to check for that member, and once found, `switch` into a handler for that specific type of message.  Therefore in this section we will leverage what was learned in the various _Properties_ tutorial pieces to establish an `ApiBase` class with a `topic` member that is read-only (to the application).  We will then build off this to explore some avenues that might make this more friendly to C/C++ application development.
+
+In the tutorial header, begin by adding:
+
+```cpp
+struct ApiBase {
+  ApiBase(const std::string &topic = "") : __topic(topic) {}
+  virtual ~ApiBase() {}
+
+  auto Topic() { return __topic; }
+
+  private:
+  std::string __topic;
+
+  RTTR_ENABLE();
+  RTTR_REGISTRATION_FRIEND;
+};
+```
+
+For now we will let the enumerated topic be just a string even though we know from experience this results in a lot of defensive programming patterns that we could get around if we were dealing with an actual `enum class` (we'll do that later).
+
+Having said that caveat though, the above should look familiar.  The structure can be created with a `topic`, which will be used as our indicator of which subclass we can expect the members to match.  The _getter_ for that member will not be registered; it is for the application to use.  Instead we are identifying the `ApiBase` as a having RTTR as a friend.
+
+Next, add a couple derived message classes to the tutorial header:
+
+```cpp
+struct ApiFirst : public ApiBase {
+  ApiFirst() : ApiBase("first") {}
+  virtual ~ApiFirst() {}
+
+  std::vector<long> longs;
+
+  RTTR_ENABLE(ApiBase);
+};
+
+struct ApiSecond : public ApiBase {
+  ApiSecond() : ApiBase("second") {}
+  virtual ~ApiSecond() {}
+
+  std::map<std::string, std::string> kvps;
+
+  RTTR_ENABLE(ApiBase);
+};
+```
+
+> NOTE: The argument passed to `RTTR_ENABLE(...)` is the parent class.
+
+Then change to the tutorial source to register these types:
+
+```cpp
+  ::rttr::registration::class_<ApiBase>("api-base")
+    .property("topic", &ApiBase::__topic)
+    ;
+
+  ::rttr::registration::class_<ApiFirst>("api-first")
+    .property("longs", &ApiFirst::longs)
+    ;
+
+  ::rttr::registration::class_<ApiSecond>("api-second")
+    .property("kvps", &ApiSecond::kvps)
+    ;
+```
+
+Again, there nothing extravagant or out-of-the-ordinary with what was added.  The base and derived classes are all registered with their unique properties that are specific to the derived class itself.
+
+Now, continue over to the tutorial test to do a basic sanity check for that base class:
+
+```cpp
+TEST(ApiTutorial, TopicIsRequired) {
+  ::tutorial::ApiBase out_base;
+  auto temp = json_from_string(R"({ 'longs': [5,6,7] })", NULL);
+
+  // Expect this to fail since 'topic' is required and missing.
+  EXPECT_FALSE(converters::from_json_glib(temp, out_base));
+  json_node_unref(temp);
+}
+```
+
+Compile and run the test.  It passes -- so far so good, right?  Now, let's verify we can inspect whatever that topic is set to be via this test:
+
+```cpp
+TEST(ApiTutorial, TopicCanBeInspected) {
+  ::tutorial::ApiBase out_base;
+
+  // This should work, as the only required field is 'topic' and the ApiBase class
+  // doesn't care what it is set to be.
+  auto temp = json_from_string(R"({ 'topic': 'first', 'longs': [1,2,3] })", NULL);
+  EXPECT_TRUE(converters::from_json_glib(temp, out_base));
+  EXPECT_EQ(out_base.Topic(), "first");
+  json_node_unref(temp);
+}
+```
+
+Compile and run the tests again.  Both tests pass because the only required field is `topic` and it can be any string.  Next, let's verify that we can _NOT_ ingest a malformed message:
+
+```cpp
+TEST(ApiTutorial, GuardOnTopic) {
+  auto temp = json_from_string(R"({ 'topic': 'second', 'longs': [1,2,3] })", NULL);
+  ::tutorial::ApiFirst out_first;
+
+  // This should _NOT_ work.  The object is malformed; the topic matches ApiSecond but the
+  // other member, 'longs', is from ApiFirst.
+  EXPECT_FALSE(converters::from_json_glib(temp, out_first));
+  json_node_unref(temp);
+}
+```
+
+Compile, run, fail.  In the next section, we will work towards fixing this by adding an enumeration and guarding on changing it.
+
+## Leveraging an Enumeration as a Guard
+
+Over in the tutorial header, change `ApiBase` to use an enumeration:
+
+```cpp
+struct ApiBase {
+  enum class TopicName {
+    not_set = -1,
+    first,
+    second
+  };
+
+  ApiBase() : __topic(TopicName::not_set) {}
+
+  virtual ~ApiBase() {}
+
+  auto Topic() { return __topic; }
+
+  protected:
+  ApiBase(TopicName topic) : __topic(topic) {}
+
+  private:
+  void __Topic(TopicName topic);
+
+  TopicName __topic = TopicName::not_set;
+
+  RTTR_ENABLE();
+  RTTR_REGISTRATION_FRIEND;
+};
+```
+
+> NOTE: we can debate whether `ApiBase` should "own" the enumeration but just go with me here.  There's no technical reason I did this; it would work fine if the `enum class` were in some other accessible namespace.
+
+We're keeping `RTTR_REGISTRATION_FRIEND` so that RTTR can call the new setter for `topic`: `__Topic(topic)`.  The implementation of that method will come in a moment which will serve as our guard against trying to marshall one JSON message into the wrong destination type by letting `topic` be our guard.  The protected constructor will be used by derived classes for setting the `topic` to the associated value for that derived class.
+
+Still in the tutorial header, update the derived classes accordingly:
+
+```cpp
+struct ApiFirst : public ApiBase {
+  ApiFirst() : ApiBase(TopicName::first) {}
+  virtual ~ApiFirst() {}
+
+  std::vector<long> longs;
+
+  RTTR_ENABLE(ApiBase);
+};
+
+struct ApiSecond : public ApiBase {
+  ApiSecond() : ApiBase(TopicName::second) {}
+  virtual ~ApiSecond() {}
+
+  std::map<std::string, std::string> kvps;
+
+  RTTR_ENABLE(ApiBase);
+};
+```
+
+In the tutorial source, and above the `RTTR_REGISTRATION` section, define `ApiBase::__Topic(topic)`:
+
+```cpp
+void tutorial::ApiBase::__Topic(TopicName topic) {
+  // Allow this to get serialized to anything exactly once.
+  if (__topic != TopicName::not_set && topic != __topic)
+    throw ::lldc::reflection::exceptions::ReferenceValueComparisonMismatch();
+  __topic = topic;
+}
+// vvv --- RTTR_PLUGIN_REGISTRATION --- vvv
+```
+
+If RTTR attempts to set the topic to something other than the currently-set value (and it isn't the default) then throw an exception.  Otherwise, store the incoming value.  This will allow our inspection to work as well as guard against trying to _change_ the topic when fully deserializing the message.
+
+Within the `RTTR_PLUGIN_REGISTRATION` section, add the enumeration:
+
+```cpp
+::rttr::registration::enumeration<ApiBase::TopicName>("api-base::topic-name")
+(
+  rttr::value("not_set", ApiBase::TopicName::not_set),
+  rttr::value("first", ApiBase::TopicName::first),
+  rttr::value("second", ApiBase::TopicName::second)
+);
+```
+
+The above change in the tutorial source allows for RTTR to marshall a string value of `first` in this case to a value of 0, making the writing of switch statements and other comparisons fairly cheap compared to dealing with strings everywhere.
+
+We also need to update the `ApiBase` registration to use the getter/setter for the `topic` member so that the guard functionality will work:
+
+```cpp
+::rttr::registration::class_<ApiBase>("api-base")
+  .property("topic", &ApiBase::Topic, &ApiBase::__Topic)
+  ;
+```
+
+Next, update the tutorial test.  The `TopicIsRequired` test needs no changes, however `TopicCanBeInspected` need to change to using the enumeration:
+
+```cpp
+TEST(ApiTutorial, TopicCanBeInspected) {
+  ::tutorial::ApiBase out_base;
+
+  // This should work, as the only required field is 'topic' and the ApiBase class
+  // doesn't care what it is set to be.
+  auto temp = json_from_string(R"({ 'topic': 'first', 'longs': [1,2,3] })", NULL);
+  EXPECT_TRUE(converters::from_json_glib(temp, out_base));
+  EXPECT_EQ(out_base.Topic(), ::tutorial::ApiBase::TopicName::first);
+  json_node_unref(temp);
+}
+```
+
+Compile and run the tests.  The previously-failing `GuardOnTopic` test now passes because thrown exception _prevented_ converting that incoming object into the wrong destination type.
+
+> For the learner: What would you need to add to that test to verify the referenced JSON cannot be read into an `ApiSecond` object either (since it has no `longs` member and the `kvps` is missing)?
+
+Thanks to the above, one could conceivably write an application which routes messages based on the topic by using the base class as a template:
+
+```cpp
+// bool handle_api_first(const &ApiFirst msg) { ... }
+
+bool initial_handler (JsonNode *raw) {
+  ::tutorial::ApiBase temp;
+
+  if (!converters::from_json_glib(raw, temp))
+    return false;
+
+  bool handled = false;
+  switch (temp.Topic()) {
+    case ApiBase::TopicName::first: {
+      ::tutorial::ApiFirst temp_first;
+      if (converters::from_json_glib(raw, temp_first))
+        handled = handle_api_first(temp_first);
+      break;
+    }
+    // and so forth...
+    default:
+      break;
+  }
+
+  return handled;
+}
+```
+
+The alternative to this would be repeated attempts at conversion, like this:
+
+```cpp
+// bool handle_api_first(const &ApiFirst msg) { ... }
+
+bool initial_handler (JsonNode *raw) {
+  bool handled = false;
+  ::tutorial::ApiFirst temp_first;
+  ::tutorial::ApiSecond temp_second;
+  // and so on, and on...
+
+  if (converters::from_json_glib(raw, temp_first)) {
+    handled = handle_api_first(temp_first);
+  }
+  else if (/** wheeee.... **/) {
+    // deal with an ApiSecond
+  }
+
+  return handled;
+}
+```
+
+Which is more performant will be related to how many messages one has to serialize to get the right one and not so much how large the incoming JSON blob is.  The conversion to the `JsonNode` in this case would have occurred already exactly once.  The conversion from `JsonNode` to the target type is constrained by the definition of the target type (i.e., the `ApiBase` only has a single property, so the conversion process only checks for that one named member in the `JsonNode`).
+
+## Conclusions
+
+This tutorial showed how to identify subclasses of structures to establish a message hierarchy that one might see in an an API.  A `topic` enumeration was then added along with making use of the getter/setter registration to establish our serialization/deserialization guard so that the reflection library can do the defensive programming for us at the time of conversion.  And finally, a pair of examples were shown for how this API might look in a message router application.

--- a/tutorial/doc/05-optional-data-members.md
+++ b/tutorial/doc/05-optional-data-members.md
@@ -1,0 +1,249 @@
+# Optional Data Members
+
+This tutorial introduces an RTTR feature: metadata.  The reflection library uses that feature to codify the idea of _optional_ members and members whose value should determine if it is treated as _optional_.  Testing in this section will involve printing our results into the test log (i.e., visual verification).
+
+The files you will be editing are:
+
+| Referred to as | Location |
+| -------------- | -------- |
+| _tutorial header_ | `lib/include/tutorial.hpp` |
+| _tutorial source_ | `lib/src/tutorial.cpp` |
+| _tutorial test_ | `tests/src/tutorial-test.cpp` |
+
+## A Foreword on the Converters
+
+This reflection library's converters use of _optional_ members is nuanced since some members are value types whereas other members have the ability to be _empty_ or otherwise appear _not set_ (`null`).  It is important to keep those distinctions in mind when extending this tutorial's design with other container types.
+
+Moreover the concept of _optional_ is applied bidirectionally.  In the conversion _away from_ the C++ type, _optional_ provides a way to **not represent** a member in the target type if the source meets some condition(s) like emptiness.  Conversely, restoring to the C++ type,  _optional_ provides a way to **not fail** deserialization (return `false`) if the source type is missing the member entirely.
+
+Then there is the concept of _optional with a default_.  This metadata feature means almost nothing on the restoration side since if the source type contains the member, the converter will make an attempt to apply it to the target C++ type.  On the other hand, in conversions _from_ the C++ type to a target type, comparing the named _default_ (via `==`) to the stored value of the source type provides the path to not represent that member in the target type.  If the value does not match the default, it is treated as required.
+
+This tutorial will provide some examples of these statements; the tests in the reflection library provide several others.
+
+## Getting Started
+
+Let us begin with a structure having value members, one of which has the concept of being empty.  To the tutorial header, add:
+
+```cpp
+struct Sometimes {
+  Sometimes() {}
+  virtual ~Sometimes() {}
+
+  long number;
+  std::string text;
+
+  RTTR_ENABLE();
+};
+```
+
+In the tutorial source, register the new type:
+
+```cpp
+::rttr::registration::class_<Sometimes>("sometimes")
+  .property("number", &Sometimes::number)
+  .property("text", &Sometimes::text)
+  ;
+```
+
+Both members are now **required** for serializing both _to_ and _from_ the target type, `JsonNode`.  Let's add a test and look at the log output.  Add the following to the tutorial test:
+
+```cpp
+TEST(Optional, PrintSometimes) {
+  ::tutorial::Sometimes sometimes;
+  JsonNode* temp = NULL;
+
+  ASSERT_TRUE((temp = converters::to_json_glib(sometimes)));
+  auto out = json_to_string(temp, true);
+
+  std::cout << out << std::endl;
+
+  g_free(out);
+  json_node_unref(temp);
+}
+```
+
+Compile and run the test, then open the log.  You should see something like the following since `std::string` would have initialized empty, and the value is just whatever happened to be in memory (depending on what compiler you are using):
+
+```bash
+[----------] 1 test from Optional
+[ RUN      ] Optional.PrintSometimes
+{
+  "number" : 94635773910520,
+  "text" : ""
+}
+[       OK ] Optional.PrintSometimes (0 ms)
+[----------] 1 test from Optional (0 ms total)
+```
+
+Great.  Both are required, therefore both are represented in the target type.
+
+## Behavior of _Optional_
+
+Now, let's go make `text` optional.  Open the tutorial source and make that change:
+
+```cpp
+::rttr::registration::class_<Sometimes>("sometimes")
+  .property("number", &Sometimes::number)
+  .property("text", &Sometimes::text) (
+    ::lldc::reflection::metadata::set_is_optional()
+  )
+  ;
+```
+
+Compile, run the test again, and check the log.  It should again have `number` printed, but now `text`, because it's _optional_ and empty-like, is omitted.
+
+```bash
+[----------] 1 test from Optional
+[ RUN      ] Optional.PrintSometimes
+{
+  "number" : 94404035604360
+}
+[       OK ] Optional.PrintSometimes (0 ms)
+[----------] 1 test from Optional (0 ms total)
+```
+
+Repeat that procedure for `number` back in the tutorial source:
+
+```cpp
+::rttr::registration::class_<Sometimes>("sometimes")
+  .property("number", &Sometimes::number) (
+    ::lldc::reflection::metadata::set_is_optional()
+  )
+  .property("text", &Sometimes::text) (
+    ::lldc::reflection::metadata::set_is_optional()
+  )
+  ;
+```
+
+Compile and re-run the test.
+
+You'll observe the `number` member is still printed despite being optional.  There is no way to check for emptiness on this type, so as far as it pertains to the converter, _optional_ in this context really only means that if the **incoming** JSON blob is missing the member, that's fine, "please continue."  For the impacted member, you will get whatever the class-initialized value of that member happened to be once the conversion is finished.  If you want a value -type member to be skipped in the conversion _to_ the intermediate type, you need to provide a default reference value.
+
+> If you want a value -type member to be skipped in the conversion _to_ the intermediate type, you need to provide a default reference value.
+
+As an exercise left to the learner, what would you expect for marking a pointer -like member as optional?  (_Answer:_ if it's `null`, it will be skipped.)
+
+## Behavior of _Optional with Default_
+
+Now, how can we omit `number` from the JSON object?  This is where the _optional with default_ behavior becomes useful:
+
+```cpp
+// tutorial source
+::rttr::registration::class_<Sometimes>("sometimes")
+  .property("number", &Sometimes::number) (
+    ::lldc::reflection::metadata::set_is_optional_with_default(1234)
+  )
+  .property("text", &Sometimes::text) (
+    ::lldc::reflection::metadata::set_is_optional()
+  )
+  ;
+```
+
+Modify the test to run the procedure twice, once with the `number` member set to the magic `1234` value:
+
+```cpp
+TEST(Optional, PrintSometimes) {
+  ::tutorial::Sometimes sometimes;
+  JsonNode* temp = NULL;
+  char* out = NULL;
+
+  sometimes.number = 1233;
+  ASSERT_TRUE((temp = converters::to_json_glib(sometimes)));
+  ASSERT_TRUE((out = json_to_string(temp, true)));
+  std::cout << out << std::endl;
+  g_free(out);
+  json_node_unref(temp);
+
+  sometimes.number = 1234;
+  ASSERT_TRUE((temp = converters::to_json_glib(sometimes)));
+  ASSERT_TRUE((out = json_to_string(temp, true)));
+  std::cout << out << std::endl;
+  g_free(out);
+  json_node_unref(temp);
+}
+```
+
+Compile and re-run the test, the log output should show an object with `number` set to `1233` (non-default value) and the second object will be empty, since both members now can meet the optionality criteria.
+
+```bash
+[----------] 1 test from Optional
+[ RUN      ] Optional.PrintSometimes
+{
+  "number" : 1233
+}
+{}
+[       OK ] Optional.PrintSometimes (0 ms)
+[----------] 1 test from Optional (0 ms total)
+```
+
+How does this work for object members that can support empty-like checks?  Let's find out.
+
+```cpp
+// tutorial source
+::rttr::registration::class_<Sometimes>("sometimes")
+  .property("number", &Sometimes::number)
+    (::lldc::reflection::metadata::set_is_optional_with_default(1234))
+  .property("text", &Sometimes::text)
+    (::lldc::reflection::metadata::set_is_optional_with_default("default"))
+  ;
+```
+
+Now, update the tutorial test to validate that `text` will be skipped if it matches `"default"`,  but will be present if it's empty (since that is not the default):
+
+```cpp
+TEST(Optional, PrintSometimes) {
+  ::tutorial::Sometimes sometimes;
+  JsonNode* temp = NULL;
+  char* out = NULL;
+
+  // If it matches the default value, it should not be present
+  // in the JSON blob.
+  sometimes.number = 0;
+  sometimes.text = "default";
+  ASSERT_TRUE((temp = converters::to_json_glib(sometimes)));
+
+  auto temp_obj = json_node_get_object(temp);
+  EXPECT_FALSE(json_object_has_member(temp_obj, "text"));
+
+  ASSERT_TRUE((out = json_to_string(temp, true)));
+  std::cout << out << std::endl;
+  g_free(out);
+  json_node_unref(temp);
+
+  // If it is empty-like (i.e., empty string), then it should
+  // be represented as an empty string in the JSON blob since
+  // it does not match the default value.
+  sometimes.text.clear();
+  ASSERT_TRUE((temp = converters::to_json_glib(sometimes)));
+
+  temp_obj = json_node_get_object(temp);
+  EXPECT_TRUE(json_object_has_member(temp_obj, "text"));
+
+  ASSERT_TRUE((out = json_to_string(temp, true)));
+  std::cout << out << std::endl;
+  g_free(out);
+  json_node_unref(temp);
+}
+```
+
+Compile and run the test.  Your results should be:
+
+```bash
+[----------] 1 test from Optional
+[ RUN      ] Optional.PrintSometimes
+{
+  "number" : 0
+}
+{
+  "number" : 0,
+  "text" : ""
+}
+[       OK ] Optional.PrintSometimes (0 ms)
+[----------] 1 test from Optional (0 ms total)
+```
+
+The first check is now skipping the `text` member because it was set to the default, and the second check included `text` because it no longer matched the default.
+
+## Conclusions
+
+This tutorial discussed the _Optional_ and _Optional with Default_ metadata features provided by this library.  You learned how to declare members as optional, explored the behavior of value vs. empty-like members, and then explored the impact of specifying a default value.

--- a/tutorial/doc/06-how-to-use-blob.md
+++ b/tutorial/doc/06-how-to-use-blob.md
@@ -1,0 +1,93 @@
+# How to Use _Blob_
+
+Extending the other tutorial on leveraging the optionality metadata, this tutorial looks at the _blob_ metadata and its potential use cases.  The general concept is having a member which should be stored as-is when doing the conversion _to_ a target type, and if encountered when deserializing back to the C++ type, again: leave it as-is.  The assumption used in this library's conveters are that the C++ type's member will be a string-like container.
+
+The files you will be editing are:
+
+| Referred to as | Location |
+| -------------- | -------- |
+| _tutorial header_ | `lib/include/tutorial.hpp` |
+| _tutorial source_ | `lib/src/tutorial.cpp` |
+| _tutorial test_ | `tests/src/tutorial-test.cpp` |
+
+## Getting Started
+
+We will be working with two structures, the main message and a payload which we will assume could be any number of other object types.  In the tutorial header, declare the message and a potential payload:
+
+```cpp
+struct BlobPayloadOne {
+  BlobPayloadOne() {}
+  virtual ~BlobPayloadOne() {}
+
+  std::vector<long> values;
+
+  RTTR_ENABLE();
+};
+
+struct BlobDelivery {
+  BlobDelivery() {}
+  virtual ~BlobDelivery() {}
+
+  std::string payload;
+
+  RTTR_ENABLE();
+};
+```
+
+In the tutorial source, register the types and identify the `payload` member as being a blob.
+
+```cpp
+::rttr::registration::class_<BlobDelivery>("blob-delivery")
+  .property("payload", &BlobDelivery::payload) (
+    ::lldc::reflection::metadata::set_is_blob()
+  )
+  ;
+
+::rttr::registration::class_<BlobPayloadOne>("blob-payload-one")
+  .property("values", &BlobPayloadOne::values)
+  ;
+```
+
+The tutorial test for this change will show that the whole incoming JSON can be converted to the `BlobDelivery` type, and that the `payload` member will be populated afterwards.  The test then goes on to verify that `payload` string is a valid JSON object resulting in a `BlobPayloadOne` type with a single number in its `values` vector, 5.
+
+```cpp
+TEST(Blob, BlobDelivery) {
+  ::tutorial::BlobDelivery output;
+  auto temp = json_from_string(R"({ 'payload': { 'values': [5] } })", nullptr);
+
+  ASSERT_TRUE(temp);
+  EXPECT_TRUE(converters::from_json_glib(temp, output));
+  EXPECT_GT(output.payload.size(), 0);
+  json_node_unref(temp);
+
+  ::tutorial::BlobPayloadOne payload_one;
+  EXPECT_TRUE(converters::json_glib::from_json(output.payload, payload_one));
+  ASSERT_EQ(payload_one.values.size(), 1);
+  EXPECT_EQ(payload_one.values[0], 5);
+}
+```
+
+This shows how to potentially handle variations of a single base message without having to define multiple base types or re-serializing the whole incoming blob a second time as was shown in the second tutorial, _Getters, Setters, and Friends_.  But, if we combine the two patterns, we can choose portions of a JSON blob to be interpreted by different handlers.
+
+## Alternative Pattern
+
+As mentioned at the end of the previous section, it would be possible to combine the getter/setter pattern with the blobbing pattern to pull the serialization and deserialization routines into your own library for particular members of your objects.  That effort is left for the learner, however here is a rough sketch of the design:
+
+1. You have a base class which provides virtual getter and setter methods for the raw type, typically `std::string`, along with a private instance of that type.  This class would be both `RTTR_ENABLE` and `RTTR_REGISTRATION_FRIEND`.
+2. Register that base class and that property with its getter and setter.
+3. Declare a derived class that implements and/or overrides the getter and setter methods of the base class.  Make those function definitions handle the conversions to and from `std::string` according to your needs.
+
+Your derived class should inherit from the base class but does not need to have `RTTR_ENABLE` or be registered unless you are also adding additional properties to serialize.  Instead, you will leverage the converter like this:
+
+```cpp
+MyDerivedType output;
+converters::from_json_glib(json_obj, (BaseType)output);
+```
+
+Casting to the base type ensures that the registration of the base class ensures the named property is appropriately mapped to the getter and setter, and inheritance will ensure your derived class methods are called for actually handling the contents.
+
+This could also be a useful way to not store the value of a member in an object (like a secret phrase), instead using the setter as a means to perform configuration upon serialization.  _However_, as interesting as that sounds, keep in mind that the marshalling of the `output` type through the converter involves potentially _many_ copy calls.  Design your class accordingly.
+
+## Conclusion
+
+This tutorial briefly showcased how to retain-but-skip a particular member of an object by treating it as a blob (in this case, a JSON stringified object).  A few potential use cases for this feature were also discussed.

--- a/tutorial/lib/include/meson.build
+++ b/tutorial/lib/include/meson.build
@@ -1,0 +1,1 @@
+libtutorial_inc = include_directories('.')

--- a/tutorial/lib/include/tutorial.hpp
+++ b/tutorial/lib/include/tutorial.hpp
@@ -1,0 +1,5 @@
+#include <lldc-reflection/declaration.h>
+
+namespace tutorial {
+  // Do stuff here.
+}; // tutorial namespace

--- a/tutorial/lib/meson.build
+++ b/tutorial/lib/meson.build
@@ -1,0 +1,15 @@
+subdir('include')
+subdir('src')
+
+libtutorial_deps = [lldc_reflection_dep.as_system()]
+
+libtutorial = shared_library ('tutorial', libtutorial_src,
+  include_directories: libtutorial_inc,
+  dependencies:        libtutorial_deps,
+  install:             false)
+
+libtutorial_dep = declare_dependency(
+  link_with:           libtutorial,
+  include_directories: libtutorial_inc,
+  dependencies:        libtutorial_deps,
+)

--- a/tutorial/lib/src/meson.build
+++ b/tutorial/lib/src/meson.build
@@ -1,0 +1,3 @@
+libtutorial_src = files([
+  'tutorial.cpp',
+])

--- a/tutorial/lib/src/tutorial.cpp
+++ b/tutorial/lib/src/tutorial.cpp
@@ -1,0 +1,12 @@
+#include "tutorial.hpp"
+
+#include <lldc-reflection/registration.h>
+
+
+RTTR_PLUGIN_REGISTRATION {
+  /**
+   * Here you will map structs and struct members to how RTTR will deal with it.
+   */
+  using namespace tutorial;
+
+}; // registration

--- a/tutorial/meson.build
+++ b/tutorial/meson.build
@@ -1,0 +1,11 @@
+if host_machine.system() == 'windows'
+  # Supporting windows would require doing all the declspec
+  # decorating of the dynamic library so that the test can
+  # link to the library, which is an exercise left for the
+  # learner.  See how the lldc-reflection library does it,
+  # which is based off JsonGlib and other similar libraries.
+  error('The tutorial currently does not support Windows')
+endif
+
+subdir('lib')
+subdir('tests')

--- a/tutorial/tests/include/meson.build
+++ b/tutorial/tests/include/meson.build
@@ -1,0 +1,1 @@
+tutorial_test_inc = include_directories('.')

--- a/tutorial/tests/meson.build
+++ b/tutorial/tests/meson.build
@@ -1,0 +1,21 @@
+gtest_dep = dependency('gtest',
+  fallback: ['gtest', 'gtest_dep'],
+  include_type: 'system')
+
+subdir('include')
+subdir('src')
+
+tutorial_test_deps = [
+  libtutorial_dep,
+  gtest_dep,
+]
+
+tutorial_test_exe = executable('tutorial-test', tutorial_test_src,
+  include_directories: tutorial_test_inc,
+  dependencies:        tutorial_test_deps,
+  install:             false,
+)
+
+test('tutorial-test', tutorial_test_exe,
+  protocol: 'gtest',
+)

--- a/tutorial/tests/src/meson.build
+++ b/tutorial/tests/src/meson.build
@@ -1,0 +1,3 @@
+tutorial_test_src = files([
+  'tutorial-test.cpp',
+])

--- a/tutorial/tests/src/tutorial-test.cpp
+++ b/tutorial/tests/src/tutorial-test.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+#include <tutorial.hpp>
+
+#include <lldc-reflection/converters/json-glib.h>
+
+namespace converters = lldc::reflection::converters;
+
+/**
+ * Insert GTests below per the tutorial.
+ */
+
+TEST(Sanity, DoesNothing) {
+  EXPECT_TRUE(true);
+}
+
+// Standard c/c++ + GTest skeleton
+int main (int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Our linked, shared library w/o the extension.
+  // If you find serialization/deserialization is doing nothing, it's probably
+  // because for some reason your shared library hasn't been loaded into the runtime
+  // and therefore none of the RTTR static registration methods have been called.
+  // If your library defines any methods (not constructors, etc.) that are called
+  // by your application, then chances are you will not have to deal with this.
+  auto lib = ::rttr::library("tutorial");
+  if (lib.load())
+    return RUN_ALL_TESTS();
+  return -1;
+}


### PR DESCRIPTION
This PR includes:

* Changes related to compiling with GCC with `-werror`.
* Adds a tutorial/walk-through for registering a structure and then verifying increased complexity via automated testing.
* Fixes a pair of bugs related to how `optional` and `optional_with_default` behave.
* Fixed a bug that prevented `blob` from being handled / stored to the target type.